### PR TITLE
fix: Implemented "window function" to calculate intervals and fix other notes

### DIFF
--- a/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/controllers/ProducerController.java
+++ b/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/controllers/ProducerController.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/services/ProducerServiceImpl.java
+++ b/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/services/ProducerServiceImpl.java
@@ -6,7 +6,6 @@ import com.augustin.gabriel.goldenraspberryawardsapi.entities.ProducerEntity;
 import com.augustin.gabriel.goldenraspberryawardsapi.repositories.ProducerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/services/ProducerServiceImpl.java
+++ b/src/main/java/com/augustin/gabriel/goldenraspberryawardsapi/services/ProducerServiceImpl.java
@@ -62,16 +62,18 @@ public class ProducerServiceImpl implements ProducerService {
                 Sort.by(Sort.Direction.DESC, "interval")
         );
 
-        log.info("Found {} min intervals and {} max intervals", minIntervals.size(), maxIntervals.size());
-
-        return new ProducerAwardsIntervalResponseDto(
+        ProducerAwardsIntervalResponseDto response = new ProducerAwardsIntervalResponseDto(
                 mapAwardsIntervals(minIntervals),
                 mapAwardsIntervals(maxIntervals)
         );
+
+        log.info("Found {} min intervals and {} max intervals", response.min().size(), response.max().size());
+        return response;
     }
 
     private List<AwardsIntervalResponseDto> mapAwardsIntervals(List<Object[]> awardsIntervals) {
         return awardsIntervals.stream()
+                .filter(row -> row[1] != null)
                 .map(row -> new AwardsIntervalResponseDto(
                         (String)  row[0], // producer
                         (Integer) row[1], // interval

--- a/src/test/java/com/augustin/gabriel/goldenraspberryawardsapi/integrations/ProducerServiceIntegrationTest.java
+++ b/src/test/java/com/augustin/gabriel/goldenraspberryawardsapi/integrations/ProducerServiceIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.augustin.gabriel.goldenraspberryawardsapi.integrations;
 
-import com.augustin.gabriel.goldenraspberryawardsapi.dtos.ProducerAwardsIntervalResponseDto;
 import com.augustin.gabriel.goldenraspberryawardsapi.dtos.AwardsIntervalResponseDto;
+import com.augustin.gabriel.goldenraspberryawardsapi.dtos.ProducerAwardsIntervalResponseDto;
 import com.augustin.gabriel.goldenraspberryawardsapi.entities.FilmEntity;
 import com.augustin.gabriel.goldenraspberryawardsapi.entities.ProducerEntity;
 import com.augustin.gabriel.goldenraspberryawardsapi.repositories.FilmRepository;


### PR DESCRIPTION
Observações “Iteração 1”:
- Requisito da API: o retorno da API deve mostrar o produtor com o menor intervalo e o produtor com o maior intervalo. A lógica atual invalida casos de empate, quando dois ou mais produtores possuem o mesmo intervalo mínimo ou máximo.
- Não deve ser necessário parametrizar a chamada para obter o resultado correto;
- Ao adicionar as linhas abaixo ao arquivo de dados fornecido juntamente com o teste o sistema deve apresentar dois resultados min com intervalo igual a 1 e dois resultados max com intervalo igual a 22:
> 1980; Test 1;Test 1;Matthew Vaughn;yes
> 2003; Test 2;Test 2;Matthew Vaughn;yes
> 2037; Test 3;Test 3;Matthew Vaughn;yes
